### PR TITLE
fix:UserTest response code and password hash

### DIFF
--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -12,15 +12,14 @@ class UserTest extends TestCase
     public function test_register_user(): void
     {
         $user = [
-            'id' => fake()->unique()->randomNumber(),
             'name' => fake()->name(),
-            'password' => fake()->password(),
+            'password' => bcrypt(fake()->password()),
             'email' => fake()->email()
         ];
 
         $response = $this->postJson(route('user.register'), $user);
 
-        $response->assertStatus(200);
+        $response->assertStatus(201);
 
         $this->assertDatabaseHas('users', $user);
         


### PR DESCRIPTION
also removed id.

id is auto increment on database, it's not sended on request.