### PR TITLE
Retrive a list of options from Google API Places v2 using Locale and Interests given from user

### DIFF
--- a/app/Http/Controllers/PlanningController.php
+++ b/app/Http/Controllers/PlanningController.php
@@ -5,18 +5,33 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Requests\PlanningRequest;
 use App\Models\TravelPlan;
+use Illuminate\Support\Facades\Http;
 
 class PlanningController extends Controller
 {
     public function setLocale(PlanningRequest $request, TravelPlan $travelPlan) {
 
-    /*
-        TO-DO Save planning data on session using cookies
-        I need to set the project to use cookies instead database and to initiate session on API route
+        $options = [];
 
-        $request->session()->put('city', $request->city);
-        $request->session()->put('state', $request->state);
-    */
-        return response()->json(['message' => 'Travel Planning initiated to ' . $request->city . ' at ' . $request->state, 200]);
+        foreach ($request->interests as $interest) {
+
+            $headers = [
+                'Content-Type' => 'application/json',
+                'X-Goog-Api-Key' => 'AIzaSyDB-JTCWp9RKG78YTYNJhIOGrdVddsW3P0',
+                'X-Goog-FieldMask' => 'places.id,places.displayName,places.formattedAddress,places.priceLevel,places.currentOpeningHours,places.currentSecondaryOpeningHours,places.regularOpeningHours,places.regularSecondaryOpeningHours'
+            ];
+            
+            $url = 'https://places.googleapis.com/v1/places:searchText';
+            $query = 'interests in city/state';
+            $response = Http::withHeaders($headers)->post($url, ['textQuery' => strtr($query, ['interest' => $interest,
+                                                                                                'city' => $request->city,
+                                                                                                'state' => $request->state])]);
+            $option = [$response->body()][0];
+            $option = json_decode($option, true)['places'][0];
+
+            $options = array_merge($options, $option);
+        };
+
+        return $options;
     }
 }

--- a/app/Http/Requests/PlanningRequest.php
+++ b/app/Http/Requests/PlanningRequest.php
@@ -22,8 +22,9 @@ class PlanningRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'city' => 'required',
-            'state' => 'required'
+            'city' => 'required|string',
+            'state' => 'required|string',
+            'interests' => 'required|list'
         ];
     }
 }

--- a/tests/Feature/PlannigTest.php
+++ b/tests/Feature/PlannigTest.php
@@ -12,22 +12,30 @@ class PlannigTest extends TestCase
     /**
      * A basic feature test example.
      */
-    public function test_set_locale(): void
-    {
+     private function postLocale()
+     {
         $locale = [
             'city' => fake()->city(),
-            'state' => fake()->state()
+            'state' => fake()->state(),
+            'interests' => ['parks', 'restaurants'],
         ];
 
-        $response = $this->postJson(route('planning.setLocale'), $locale);
+        return $this->postJson(route('planning.setLocale'), $locale);
+     }
 
+    public function test_payload_get_correct_status(): void
+    {
+
+        $response = $this->postLocale();
         $response->assertStatus(200);
+
+    }
+
+    public function test_has_correct_response_body(): void {
         
-        $this->assertTrue(Session::has('city'));
-        $this->assertEquals($city, Session::get('city'));
+        $response = $this->postLocale();
+        $response_data = $response->json();
 
-        $this->assertTrue(Session::has('state'));
-        $this->asserEquals($state, Session::get('state'));
-
+        $this->assertArrayHasKey('displayName', $response_data);
     }
 }


### PR DESCRIPTION
Start planning, setting locale and interests to return places wich user can select to your planning.

Now interests is a required list on payload, wich is used to retrieve data from Google API Places v2 on SearchText Endpoint.

On tests, Status Code must be 200 and response json must have displayName field.