### PR TITLE
hotfix:Remove hard-coded api key and passed it to env

### DIFF
--- a/app/Http/Controllers/PlanningController.php
+++ b/app/Http/Controllers/PlanningController.php
@@ -17,7 +17,7 @@ class PlanningController extends Controller
 
             $headers = [
                 'Content-Type' => 'application/json',
-                'X-Goog-Api-Key' => 'AIzaSyDB-JTCWp9RKG78YTYNJhIOGrdVddsW3P0',
+                'X-Goog-Api-Key' => env('GCP_ACCESS_KEY', ''),
                 'X-Goog-FieldMask' => 'places.id,places.displayName,places.formattedAddress,places.priceLevel,places.currentOpeningHours,places.currentSecondaryOpeningHours,places.regularOpeningHours,places.regularSecondaryOpeningHours'
             ];
             

--- a/tests/Feature/PlanningTest.php
+++ b/tests/Feature/PlanningTest.php
@@ -7,7 +7,7 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Session;
 use Tests\TestCase;
 
-class PlannigTest extends TestCase
+class PlanningTest extends TestCase
 {
     /**
      * A basic feature test example.


### PR DESCRIPTION
Removed api key from controller, passed in env and called on controller to security propurses
IMPORTANT: This API Keys has been deleted, a new one was created.

minor: also corrected PlanningTest filename